### PR TITLE
load data via docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ benchmark timescaledb using a csv as input for the queries
 
 [See Architecture](docs/ARCHITECTURE.md)
 
-# Running timescale
+# Running timescale and benchmark via docker
 1. Run `docker-compose build`
-2. To start timescale run `docker-compose up`
-3. To load the time series data run `docker-compose exec timescaledb psql -U postgres -h localhost -f /tmp/db/cpu_usage.sql`
-4. to see the process run automatically, kill `docker-compose up`
+2. To start timescale run ` docker-compose up timescaledb`
+3. To load the time series data, In a new terminal run `docker-compose exec timescaledb psql -U postgres -h localhost -f /tmp/db/cpu_usage.sql`
+4. to see the process run automatically  `docker-compose up`
 5. run `docker-compose up | grep benchmark_1`
-6. had some issues getting the sql in using one step so thats why its a start and kill for now
+6. leave timescale running
 
 # Running the Tests
 To run the tests we can use the make file, assuming you have go installed


### PR DESCRIPTION
https://github.com/shawnfeldman/timescale-benchmark/issues/11
update readme to have better instructions on running from docker-compose
probably is a better way to do this but for now this gets it done